### PR TITLE
Fix pkg_install when no deps are installed

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -23,9 +23,9 @@ pkg_install <- function(pkg, lib = .libPaths()[[1L]], num_workers = 1L) {
 
   # Get the installation plan and ignore already installed versions.
   plan <- r$get_install_plan()
-  dependencies <- plan[!plan$direct, ]
-  uninstalled_plan <- dependencies[dependencies$type != "installed", ]
-  if (nrow(uninstalled_plan) == 0) {
+  needs_install <- plan[plan$type != "installed", ]
+  if (nrow(needs_install) == 0) {
+    dependencies <- plan[!plan$direct, ]
     message(glue::glue("
         {green_tick()} {blue(pkg)} and its {blue(nrow(dependencies))} \\
         dependencies already installed"))


### PR DESCRIPTION
But the directly specified `pkg` needs to
be (re)installed.

E.g. 

```
pkg_install("r-lib/crayon")
pkg_install("cran::crayon")
```

The second should reinstall `crayon` from CRAN.