### PR TITLE
Improve output when no installs needed

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -22,12 +22,14 @@ pkg_install <- function(pkg, lib = .libPaths()[[1L]], num_workers = 1L) {
 
   # Do we need to do anything?
   if (nrow(needs_install) == 0) {
-    plan$num_deps <- total_num_deps(plan)
-    dir <- plan[plan$direct, ]
-    ind <- plan[!plan$direct, ]
-    for (i in seq_len(nrow(dir))) {
-      msg_success("{fmt_pkg(dir$package[i])} {fmt_ver(dir$version[i])} \\
+    if (is_verbose()) {
+      plan$num_deps <- total_num_deps(plan)
+      dir <- plan[plan$direct, ]
+      ind <- plan[!plan$direct, ]
+      for (i in seq_len(nrow(dir))) {
+        msg_success("{fmt_pkg(dir$package[i])} {fmt_ver(dir$version[i])} \\
                    and {dir$num_deps[i]} dependencies already installed")
+      }
     }
 
   } else {
@@ -37,8 +39,14 @@ pkg_install <- function(pkg, lib = .libPaths()[[1L]], num_workers = 1L) {
       lapply(needs_install$dependencies, setdiff, y = installed)
 
     # Install what is left
-    install_packages(needs_install$file, lib = lib, plan = needs_install,
-                     num_workers = num_workers)
+    inst_stat <- install_packages(
+      needs_install$file, lib = lib, plan = needs_install,
+      num_workers = num_workers)
+
+    if (is_verbose()) print(inst_stat)
+
+    inst_lib <- match(plan$file, names(inst_stat))
+    plan$installed[match(names(inst_stat), plan$file)] <- unlist(inst_stat)
   }
 
   invisible(plan)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,6 @@
 
+`%||%` <- function(l, r) if (is.null(l)) r else l
+
 # Adapted from withr:::merge_new
 merge_new <- function(old, new, action = c("replace", "prepend", "append")) {
   action <- match.arg(action, c("replace", "prepend", "append"))
@@ -34,4 +36,8 @@ viapply <- function(X, FUN, ...) {
 
 vdapply <- function(X, FUN, ...) {
   vapply(X, FUN, FUN.VALUE = double(1), ...)
+}
+
+is_verbose <- function() {
+  getOption("pkg.progress.bar") %||% interactive()
 }

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -1,0 +1,22 @@
+
+context("package")
+
+test_that("total_num_deps", {
+  ## linear chain
+  plan <- tibble::tibble(
+    package = c("a", "b", "c"),
+    dependencies = list("b", "c", character()))
+  expect_identical(total_num_deps(plan), c(3, 2, 1))
+
+  ## loops
+  plan <- tibble::tibble(
+    package = c("a", "b", "c"),
+    dependencies = list("b", "c", "a"))
+  expect_identical(total_num_deps(plan), c(3, 3, 3))
+
+  ## empty
+  plan <- tibble::tibble(
+    package = character(),
+    dependencies = list())
+  expect_identical(total_num_deps(plan), numeric())
+})


### PR DESCRIPTION
Looks like this now:

```
❯ pkg_install(c("dplyr", "purrr"), lib = "/tmp/lib/")
  Updating CRAN metadata
✔ CRAN metadata current
✔ Found 34 dependencies for 2 packages in 575ms
✔ No downloads are needed
✔ dplyr 0.7.4 and 13 dependencies already installed
✔ purrr 0.2.4 and 5 dependencies already installed
```