### PR TITLE
pkg_install throws proper errors

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -12,9 +12,11 @@ pkg_install <- function(pkg, lib = .libPaths()[[1L]], num_workers = 1L) {
 
   # Solve the dependency graph
   r$solve()
+  r$stop_for_solve_error()
 
   # Actually download packages as needed
   r$download_solution()
+  r$stop_for_solution_download_error()
 
   # Get the installation plan and ignore already installed versions.
   plan <- r$get_install_plan()


### PR DESCRIPTION
Closes #33 

When a `solve()` fails:
```
❯ pkg_install(c("r-lib/usethis", "cran::usethis"))
  Updating CRAN metadata
✔ CRAN metadata current
✔ Found 62 dependencies for 2 packages in 1.6s

Error: Cannot install packages:
  * Cannot install package `usethis`.
  - `cran::usethis`, conflicts with `r-lib/usethis`
  - `installed::/Users/gaborcsardi/r_pkgs/usethis`, conflicts with `r-lib/usethis`
  - `r-lib/usethis`, conflicts with `cran::usethis`
```

or when a download fails:
```
❯ pkg_install("r-lib/usethis", lib = "/tmp/lib")
  Updating CRAN metadata
✔ Updated CRAN metadata
✔ Found 23 dependencies for 1 packages in 2.9s
✔ 38 packages, in 6.5s

Error: Cannot download some packages:
Failed to download Rcpp from `https://cran.rstudio.com/bin/macosx/el-capitan/contrib/3.4/Rcpp_0.12.14.tgz`.
Failed to download rstudioapi from `https://cran.rstudio.com/bin/macosx/el-capitan/contrib/3.4/rstudioapi_0.7.tgz`.
Failed to download knitr from `https://cran.rstudio.com/bin/macosx/el-capitan/contrib/3.4/knitr_1.18.tgz`.
Failed to download rematch2 from `https://cran.rstudio.com/bin/macosx/el-capitan/contrib/3.4/rematch2_2.0.1.tgz`.
Failed to download whisker from `https://cran.rstudio.com/bin/macosx/el-capitan/contrib/3.4/whisker_0.3-2.tgz`.
Failed to download magrittr from `https://cran.rstudio.com/bin/macosx/el-capitan/contrib/3.4/magrittr_1.5.tgz`.
```