### PR TITLE
add remote ref for async

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     rex (>= 1.1.2),
     tibble (>= 1.3.4)
 Remotes:
+  r-lib/async,
   r-lib/pkgdepends,
   r-lib/pkginstall
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
fixes pkgdepends::remotes$new("r-lib/pkgman") fails with `Error: invalid version specification ‘NA’` when solve()ing. Tracking down shows async is improperly given a standard ref as no remote specified.